### PR TITLE
Handle Ensembl ID suffixes and error if ID mapping failed

### DIFF
--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -125,6 +125,7 @@ def map_ensembl_ids(ensembl_ids):
     for ensembl_id in ensembl_ids:
         ref = {'HGNC_SYMBOL': None, 'HGNC': None, 'UP': None,
                'ENSEMBL': ensembl_id}
+        ensembl_id = ensembl_id.split('.', maxsplit=1)[0]
         hgnc_id = hgnc_client.get_hgnc_from_ensembl(ensembl_id)
         if not hgnc_id:
             logger.warning('Could not get HGNC ID for ENSEMBL ID %s' %

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -35,15 +35,20 @@ def read_gene_list(fname, id_type):
             if line not in unique_lines:
                 unique_lines.append(line)
     if id_type == 'hgnc_symbol':
-        return map_hgnc_symbols(unique_lines)
+        refs = map_hgnc_symbols(unique_lines)
     elif id_type == 'hgnc_id':
-        return map_hgnc_ids(unique_lines)
+        refs = map_hgnc_ids(unique_lines)
     elif id_type == 'ensembl_id':
-        return map_ensembl_ids(unique_lines)
+        refs = map_ensembl_ids(unique_lines)
     elif id_type == 'mgi_id':
-        return map_mgi_ids(unique_lines)
+        refs = map_mgi_ids(unique_lines)
     else:
         raise ValueError('Unknown id_type: %s' % id_type)
+    if not refs:
+        raise ValueError('None of the IDs in %s could be mapped. It is '
+                         'likely that the file uses an ID type or format '
+                         'that GeneWalk cannot interpret.' % fname)
+    return refs
 
 
 def map_hgnc_symbols(hgnc_symbols):

--- a/genewalk/tests/test_gene_lists.py
+++ b/genewalk/tests/test_gene_lists.py
@@ -27,3 +27,8 @@ def test_map_lists():
     assert refs[0]['HGNC'] == '1097', refs
     assert refs[0]['UP'] == 'P15056', refs
     assert refs[0]['HGNC_SYMBOL'] == 'BRAF', refs
+
+    refs = map_ensembl_ids(['ENSG00000157764.9'])
+    assert refs[0]['HGNC'] == '1097', refs
+    assert refs[0]['UP'] == 'P15056', refs
+    assert refs[0]['HGNC_SYMBOL'] == 'BRAF', refs

--- a/genewalk/tests/test_gene_lists.py
+++ b/genewalk/tests/test_gene_lists.py
@@ -1,3 +1,4 @@
+from nose.tools import raises
 from genewalk.gene_lists import *
 
 
@@ -32,3 +33,18 @@ def test_map_lists():
     assert refs[0]['HGNC'] == '1097', refs
     assert refs[0]['UP'] == 'P15056', refs
     assert refs[0]['HGNC_SYMBOL'] == 'BRAF', refs
+
+
+def test_read_gene_list():
+    with open('test_gene_list.txt', 'w') as fh:
+        fh.write('HGNC:1097')
+    refs = read_gene_list('test_gene_list.txt', 'hgnc_id')
+    assert len(refs) == 1
+
+
+@raises(ValueError)
+def test_read_gene_list_bad():
+    with open('test_gene_list.txt', 'w') as fh:
+        fh.write('HGNC:1097')
+    refs = read_gene_list('test_gene_list.txt', 'ensembl_id')
+    assert len(refs) == 1


### PR DESCRIPTION
This PR adds support for handling human Ensembl genes with .X suffixes. It also handles the case when none of the references in the input file could be mapped (indicating a systematic problem with the format or the processing of the gene list) by raising an error to stop the GeneWalk run, and display a message to the user about ID mapping having failed.

Fixes #13 