### PR TITLE
Entrez

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ required arguments:
   --genes GENES         Path to a text file with a list of differentially
                         expressed genes. Thetype of gene identifiers used in
                         the text file are provided in the id_type argument.
-  --id_type {hgnc_symbol,hgnc_id,ensembl_id,mgi_id}
+  --id_type {hgnc_symbol,hgnc_id,ensembl_id,mgi_id,entrez_human,entrez_mouse}
                         The type of gene IDs provided in the text file in the
                         genes argument. Possible values are: hgnc_symbol,
-                        hgnc_id, ensembl_id, and mgi_id.
+                        hgnc_id, ensembl_id, mgi_id, entrez_human and
+                        entrez_mouse.
 
 optional arguments:
   --stage {all,node_vectors,null_distribution,statistics}

--- a/genewalk/cli.py
+++ b/genewalk/cli.py
@@ -72,7 +72,7 @@ def main():
                              'in the genes argument. Possible values are: '
                              'hgnc_symbol, hgnc_id, ensembl_id, and mgi_id.',
                         choices=['hgnc_symbol', 'hgnc_id',
-                                 'ensembl_id', 'mgi_id'],
+                                 'ensembl_id', 'mgi_id', 'entrez'],
                         required=True)
     parser.add_argument('--stage', default='all',
                         help='The stage of processing to run. Default: '

--- a/genewalk/cli.py
+++ b/genewalk/cli.py
@@ -152,7 +152,7 @@ def main():
     rm.download_all()
 
     if args.stage in ('all', 'node_vectors'):
-        genes = read_gene_list(args.genes, args.id_type)
+        genes = read_gene_list(args.genes, args.id_type, rm)
         save_pickle(genes, project_folder, 'genes')
         MG = load_network(args.network_source, args.network_file, genes,
                           resource_manager=rm)

--- a/genewalk/cli.py
+++ b/genewalk/cli.py
@@ -72,7 +72,8 @@ def main():
                              'in the genes argument. Possible values are: '
                              'hgnc_symbol, hgnc_id, ensembl_id, and mgi_id.',
                         choices=['hgnc_symbol', 'hgnc_id',
-                                 'ensembl_id', 'mgi_id', 'entrez'],
+                                 'ensembl_id', 'mgi_id', 'entrez_human',
+                                 'entrez_mouse'],
                         required=True)
     parser.add_argument('--stage', default='all',
                         help='The stage of processing to run. Default: '

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -194,7 +194,7 @@ def map_entrez_mouse(entrez_ids, rm):
         mgi_id = entrez_to_mgi.get(entrez_id)
         if not mgi_id:
             logger.warning("Could not find an MGI mapping for Entrez ID %s"
-                         % entrez_id)
+                           % entrez_id)
             continue
         ref = {'EGID': entrez_id, 'MGI': mgi_id}
         mgi_refs = _refs_from_mgi_id(mgi_id)

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -164,6 +164,10 @@ def map_entrez_human(entrez_ids):
     for entrez_id in entrez_ids:
         ref = {'EGID': entrez_id}
         hgnc_id = hgnc_client.get_hgnc_from_entrez(entrez_id)
+        if hgnc_id is None:
+            logger.warning("Could not find HGNC ID for Entrez ID %s" %
+                           entrez_id)
+            continue
         hgnc_ref = _refs_from_hgnc_id(hgnc_id)
         if hgnc_ref is None:
             continue
@@ -189,7 +193,7 @@ def map_entrez_mouse(entrez_ids, rm):
     for entrez_id in entrez_ids:
         mgi_id = entrez_to_mgi.get(entrez_id)
         if not mgi_id:
-            logger.error("Could not find an MGI mapping for Entrez ID %s"
+            logger.warning("Could not find an MGI mapping for Entrez ID %s"
                          % entrez_id)
             continue
         ref = {'EGID': entrez_id, 'MGI': mgi_id}

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -194,6 +194,10 @@ def map_up_from_entrez(entrez_ids):
                 continue
             ref.update(mgi_ref)
             map_success[entrez_id] = True
+        # If we cannot identify human or mouse, we likely hit an unreviewed
+        # Uniprot entry
+        else:
+            continue
         refs.append(ref)
     for entrez_id, succ in map_success.items():
         if not succ:

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -182,6 +182,27 @@ def map_up_from_entrez(entrez_ids):
             gene_symbol = uniprot_client.get_gene_name(up_id)
             hgnc_id = uniprot_client.get_hgnc_id(up_id)
             ref.update({'HGNC_SYMBOL': gene_symbol, 'HGNC': hgnc_id})
+        elif uniprot_client.is_mouse(up_id):
+            # Get the MGI ID
+            mgi_id = uniprot_client.get_mgi_id(up_id)
+            # Get the orthologous human gene ID and name
+            hgnc_id = hgnc_client.get_hgnc_from_mouse(mgi_id)
+            if not hgnc_id:
+                logger.warning('Could not get HGNC ID for MGI ID %s' %
+                               mgi_id)
+                continue
+            ref['HGNC'] = hgnc_id
+            hgnc_name = hgnc_client.get_hgnc_name(hgnc_id)
+            if not hgnc_name:
+                logger.warning('Could not get HGNC name for ID %s' %
+                               hgnc_id)
+                continue
+            ref['HGNC_SYMBOL'] = hgnc_name
+        else:
+            logger.error("Genewalk only supports Entrez Gene IDs from "
+                         "human or mouse (Entrez %s, UP %s)" %
+                         (entrez_id, up_id))
+            continue
         refs.append(ref)
     return refs
 

--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -163,6 +163,8 @@ class GeneWalk(object):
                                 row = [gene.get('MGI', '')] + row
                             elif base_id_type == 'ensembl_id':
                                 row = [gene.get('ENSEMBL', '')] + row
+                            elif base_id_type == 'entrez':
+                                row = [gene.get('ENTREZ', '')] + row
                             rows.append(row)
                 elif alpha_fdr == 1:  # case: no GO connections
                     row = self.add_empty_row(gene, gene_attribs, base_id_type)

--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -99,6 +99,8 @@ class GeneWalk(object):
             row = [gene.get('MGI', '')] + row
         elif base_id_type == 'ensembl_id':
             row = [gene.get('ENSEMBL', '')] + row
+        elif base_id_type == 'entrez':
+            row = [gene.get('ENTREZ', '')] + row
         return row
 
     def generate_output(self, alpha_fdr=1, base_id_type='hgnc_symbol'):

--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -99,8 +99,9 @@ class GeneWalk(object):
             row = [gene.get('MGI', '')] + row
         elif base_id_type == 'ensembl_id':
             row = [gene.get('ENSEMBL', '')] + row
-        elif base_id_type == 'entrez':
-            row = [gene.get('ENTREZ', '')] + row
+        elif base_id_type == 'entrez_mouse' or \
+             base_id_type == 'entrez_human':
+            row = [gene.get('EGID', '')] + row
         return row
 
     def generate_output(self, alpha_fdr=1, base_id_type='hgnc_symbol'):
@@ -165,8 +166,9 @@ class GeneWalk(object):
                                 row = [gene.get('MGI', '')] + row
                             elif base_id_type == 'ensembl_id':
                                 row = [gene.get('ENSEMBL', '')] + row
-                            elif base_id_type == 'entrez':
-                                row = [gene.get('ENTREZ', '')] + row
+                            elif base_id_type == 'entrez_mouse' or \
+                                 base_id_type == 'entrez_human':
+                                row = [gene.get('EGID', '')] + row
                             rows.append(row)
                 elif alpha_fdr == 1:  # case: no GO connections
                     row = self.add_empty_row(gene, gene_attribs, base_id_type)
@@ -181,7 +183,8 @@ class GeneWalk(object):
                   'mean_pval', 'cilow_pval', 'ciupp_pval',
                   'mean_sim',  'sem_sim',
                   ]
-        if base_id_type in {'mgi_id', 'ensembl_id', 'entrez'}:
+        if base_id_type in {'mgi_id', 'ensembl_id', 'entrez_human',
+                            'entrez_mouse'}:
             header = [base_id_type] + header
 
         df = pd.DataFrame.from_records(rows, columns=header)

--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -177,7 +177,7 @@ class GeneWalk(object):
                   'mean_pval', 'cilow_pval', 'ciupp_pval',
                   'mean_sim',  'sem_sim',
                   ]
-        if base_id_type in {'mgi_id', 'ensembl_id'}:
+        if base_id_type in {'mgi_id', 'ensembl_id', 'entrez'}:
             header = [base_id_type] + header
 
         df = pd.DataFrame.from_records(rows, columns=header)

--- a/genewalk/resources.py
+++ b/genewalk/resources.py
@@ -17,7 +17,8 @@ class ResourceManager(object):
     def get_go_obo(self):
         fname = os.path.join(self.resource_folder, 'go.obo')
         if not os.path.exists(fname):
-            download_go(fname)
+            url = 'http://snapshot.geneontology.org/ontology/go.obo'
+            download_url(url, fname)
         return fname
 
     def get_goa_gaf(self):
@@ -37,6 +38,14 @@ class ResourceManager(object):
             download_gz(fname, url_pc)
         return fname
 
+    def get_mgi_entrez(self):
+        fname = os.path.join(self.resource_folder, 'MGI_EntrezGene.rpt')
+        if not os.path.exists(fname):
+            url = 'http://www.informatics.jax.org/downloads/reports/' \
+                  'MGI_EntrezGene.rpt'
+            download_url(url, fname)
+        return fname
+
     def _get_resource_folder(self):
         resource_dir = os.path.join(self.base_folder, 'resources')
 
@@ -51,10 +60,10 @@ class ResourceManager(object):
         self.get_go_obo()
         self.get_goa_gaf()
         self.get_pc()
+        self.get_mgi_entrez()
 
 
-def download_go(fname):
-    url = 'http://snapshot.geneontology.org/ontology/go.obo'
+def download_url(url, fname):
     logger.info('Downloading %s into %s' % (url, fname))
     urllib.request.urlretrieve(url, fname)
 

--- a/genewalk/tests/test_gene_lists.py
+++ b/genewalk/tests/test_gene_lists.py
@@ -1,6 +1,7 @@
 from nose.tools import raises
 from genewalk.gene_lists import *
-
+from genewalk.cli import default_base_folder
+from genewalk.resources import ResourceManager
 
 def test_map_lists():
     refs = map_hgnc_symbols(['BRAF', 'KRAS'])
@@ -48,4 +49,24 @@ def test_read_gene_list_bad():
         fh.write('HGNC:1097')
     refs = read_gene_list('test_gene_list.txt', 'ensembl_id', None)
     assert len(refs) == 1
+
+
+def test_read_gene_list_entrez_human():
+    with open('test_gene_list_entrez_human.txt', 'w') as fh:
+        fh.write('2597')
+    refs = read_gene_list('test_gene_list_entrez_human.txt',
+                          'entrez_human', None)
+    assert refs[0]['HGNC_SYMBOL'] == 'GAPDH'
+    assert len(refs) == 1
+
+
+def test_read_gene_list_entrez_mouse():
+    rm = ResourceManager(base_folder=default_base_folder)
+    with open('test_gene_list_entrez_mouse.txt', 'w') as fh:
+        fh.write('14433')
+    refs = read_gene_list('test_gene_list_entrez_mouse.txt',
+                          'entrez_mouse', rm)
+    assert len(refs) == 1
+    assert refs[0]['MGI'] == '95640'
+    assert refs[0]['HGNC_SYMBOL'] == 'GAPDH'
 

--- a/genewalk/tests/test_gene_lists.py
+++ b/genewalk/tests/test_gene_lists.py
@@ -38,7 +38,7 @@ def test_map_lists():
 def test_read_gene_list():
     with open('test_gene_list.txt', 'w') as fh:
         fh.write('HGNC:1097')
-    refs = read_gene_list('test_gene_list.txt', 'hgnc_id')
+    refs = read_gene_list('test_gene_list.txt', 'hgnc_id', None)
     assert len(refs) == 1
 
 
@@ -46,5 +46,6 @@ def test_read_gene_list():
 def test_read_gene_list_bad():
     with open('test_gene_list.txt', 'w') as fh:
         fh.write('HGNC:1097')
-    refs = read_gene_list('test_gene_list.txt', 'ensembl_id')
+    refs = read_gene_list('test_gene_list.txt', 'ensembl_id', None)
     assert len(refs) == 1
+


### PR DESCRIPTION
Adds the ability to use lists of Entrez gene IDs as input. For mouse genes, mappings to from Entrez are obtained from MGI; for human genes they are obtained from HGNC. Because the mapping procedures are different for human and mouse (and because this only applies to Entrez IDs), the ID type currently needs to specified as either `entrez_human` or `entrez_mouse`.

In addition to handling of these new id types in `cli`, `perform_statistics` and `gene_lists`, the `gene_lists` module was refactored to consolidate redundant code.