### PR TITLE
Don't download all resources up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ To install the latest code from Github (typically ahead of releases):
 pip install git+https://github.com/churchmanlab/genewalk.git
 ```
 
+GeneWalk uses a number of resource files that it downloads as needed during
+runtime. To optionally pre-download these resource files in the default resource folder,
+the command
+```
+python -m genewalk.resources
+```
+can be run.
+
 ## Using GeneWalk
 
 ### Gene list file

--- a/genewalk/cli.py
+++ b/genewalk/cli.py
@@ -162,9 +162,8 @@ def run_main(args):
         logger.info('Running with random seed %d' % args.random_seed)
         random.seed(a=int(args.random_seed))
 
-    # Make sure we have all the resource files
+    # Instantiate the resource manager
     rm = ResourceManager(base_folder=args.base_folder)
-    rm.download_all()
 
     if args.stage in ('all', 'node_vectors'):
         genes = read_gene_list(args.genes, args.id_type, rm)


### PR DESCRIPTION
This PR removes a line from the CLI which, under any set of arguments, downloads all resource files with the resource manager. This is not ideal because it will also download resource files that may not be needed for a given run (for instance with `--network_source sif`, the PathwayCommons resource file would still be downloaded even though not needed). I also added a note to the README about how one can (optionally) pre-download all resource files to avoid downloading them during runtime.