### PR TITLE
Add rows for genes with no GO annotations to results spreadsheet

### DIFF
--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -128,7 +128,7 @@ class GeneWalk(object):
                 all_go_attribs = [self.get_go_attribs(gene_attribs, nv,
                                                       alpha_fdr)
                                   for nv in self.nvs]
-                if all_go_attribs:  # gene has GO connections
+                if any(all_go_attribs):  # gene has GO connections
                     go_attrib_dict = {}
                     for go_attrib_list in all_go_attribs:
                         for go_attribs in go_attrib_list:

--- a/genewalk/plot.py
+++ b/genewalk/plot.py
@@ -258,9 +258,9 @@ class GW_Plotter(object):
             con = df['ncon_gene'].unique()[0]
             if pd.isna(df['go_id'].unique()[0]):  # no GO annotations
                 gocon = np.nan
-                genecon = np.nan
-                relgo = np.nan
-                fracrelgo = np.nan
+                genecon = con
+                relgo = 0
+                fracrelgo = 0
             else:
                 gocon = len(df)
                 genecon = con - gocon

--- a/genewalk/plot.py
+++ b/genewalk/plot.py
@@ -256,7 +256,7 @@ class GW_Plotter(object):
             df = self.dGW[ self.dGW[self.id_type] == gid ]
             gname = df['hgnc_symbol'].unique()[0]
             con = df['ncon_gene'].unique()[0]
-            if np.isnan(con):#no GO annotations
+            if pd.isna(df['go_id'].unique()[0]):  # no GO annotations
                 gocon = np.nan
                 genecon = np.nan
                 relgo = np.nan

--- a/genewalk/tests/test_cli.py
+++ b/genewalk/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import pandas
 import shutil
 import logging
 from genewalk.cli import run_main, default_base_folder
@@ -54,5 +55,8 @@ def test_default():
     run_main(args)
 
     assert os.path.exists(TEST_BASE_FOLDER)
-    assert os.path.exists(os.path.join(TEST_BASE_FOLDER, project_name,
-                                       'genewalk_results.csv'))
+    result_csv = os.path.join(TEST_BASE_FOLDER, project_name,
+                              'genewalk_results.csv')
+    assert os.path.exists(result_csv)
+    df = pandas.read_csv(result_csv)
+    assert 'MAP2K2' in set(df['hgnc_symbol']), df['hgnc_symbol']

--- a/genewalk/tests/test_cli.py
+++ b/genewalk/tests/test_cli.py
@@ -36,7 +36,7 @@ def _place_files():
     test_resource_files = glob.glob(os.path.join(HERE, 'resources', '*'))
     test_resource_folder = \
         os.path.join(TEST_BASE_FOLDER, 'resources')
-    os.makedirs(test_resource_folder)
+    os.makedirs(test_resource_folder, exist_ok=True)
     for test_file in test_resource_files:
         logger.debug('Copying %s into %s' % (test_file, test_resource_folder))
         shutil.copy(test_file,


### PR DESCRIPTION
This PR fixes an issue that resulted in genes with no GO annotations not being included (with an empty row) in the results spreadsheet, even if alpha FDR was set to 1. It also fixes a check in the plotting code for the corner case of a gene with no GO annotations.