### PR TITLE
Add support for rat gene lists using RGD

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ GeneWalk always requires as input a text file containing a list with genes of in
 relevant to the biological context. For example, differentially expressed genes
 from a sequencing experiment that compares an experimental versus control condition.
 GeneWalk supports gene list files containing HGNC human gene symbols,
-HGNC IDs, human Ensembl gene IDs, MGI mouse gene IDs, or human or mouse entrez IDs. 
-Each line in the file contains a gene identifier of one of these types.
+HGNC IDs, human Ensembl gene IDs, MGI mouse gene IDs, RGD rat gene IDs, or
+human or mouse entrez IDs. Each line in the file contains a gene identifier
+of one of these types.
 
 ### GeneWalk command line interface
 Once installed, GeneWalk can be run from the command line as `genewalk`, with
@@ -55,7 +56,7 @@ Below is the full documentation of the command line interface:
 
 ```
 genewalk [-h] [--version] --project PROJECT --genes GENES --id_type
-              {hgnc_symbol,hgnc_id,mgi_id,ensembl_id}
+              {hgnc_symbol,hgnc_id,ensembl_id,mgi_id,rgd_id,entrez_human,entrez_mouse}
               [--stage {all,node_vectors,null_distribution,statistics}]
               [--base_folder BASE_FOLDER]
               [--network_source {pc,indra,edge_list,sif}]
@@ -73,10 +74,10 @@ required arguments:
   --genes GENES         Path to a text file with a list of differentially
                         expressed genes. Thetype of gene identifiers used in
                         the text file are provided in the id_type argument.
-  --id_type {hgnc_symbol,hgnc_id,ensembl_id,mgi_id,entrez_human,entrez_mouse}
+  --id_type {hgnc_symbol,hgnc_id,ensembl_id,mgi_id,rgd_id,entrez_human,entrez_mouse}
                         The type of gene IDs provided in the text file in the
                         genes argument. Possible values are: hgnc_symbol,
-                        hgnc_id, ensembl_id, mgi_id, entrez_human and
+                        hgnc_id, ensembl_id, mgi_id, rgd_id, entrez_human and
                         entrez_mouse.
 
 optional arguments:
@@ -224,7 +225,7 @@ hypothesis testing. Average over nreps_graph repeat runs.
 - cilow_pval - lower bound of 95% confidence interval on pval (mean estimate)
 from the nreps_graph repeat analyses.
 - ciupp_pval - upper bound of 95% confidence interval on pval.
-- mgi_id, ensembl_id, mgi_id, entrez_human or entrez_mouse - in case one of
+- mgi_id, rgd_id, ensembl_id, entrez_human or entrez_mouse - in case one of
   these gene identifiers were provided as input, the GeneWalk results table
   starts with an additional column to indicate the gene identifiers. In the
   case of mouse genes, the corresponding hgnc_id and hgnc_symbol resemble its

--- a/genewalk/cli.py
+++ b/genewalk/cli.py
@@ -71,10 +71,11 @@ def main():
     parser.add_argument('--id_type',
                         help='The type of gene IDs provided in the text file '
                              'in the genes argument. Possible values are: '
-                             'hgnc_symbol, hgnc_id, ensembl_id, and mgi_id.',
+                             'hgnc_symbol, hgnc_id, ensembl_id, mgi_id,'
+                             'rgd_id, entrez_human, and entrez_mouse.',
                         choices=['hgnc_symbol', 'hgnc_id',
-                                 'ensembl_id', 'mgi_id', 'entrez_human',
-                                 'entrez_mouse'],
+                                 'ensembl_id', 'mgi_id', 'rgd_id',
+                                 'entrez_human', 'entrez_mouse'],
                         required=True)
     parser.add_argument('--stage', default='all',
                         help='The stage of processing to run. Default: '

--- a/genewalk/gene_lists.py
+++ b/genewalk/gene_lists.py
@@ -45,6 +45,8 @@ def read_gene_list(fname, id_type, resource_manager):
         refs = map_ensembl_ids(unique_lines, gene_mapper)
     elif id_type == 'mgi_id':
         refs = map_mgi_ids(unique_lines, gene_mapper)
+    elif id_type == 'rgd_id':
+        refs = map_rgd_ids(unique_lines, gene_mapper)
     elif id_type == 'entrez_human':
         refs = map_entrez_human(unique_lines, gene_mapper)
     elif id_type == 'entrez_mouse':
@@ -131,6 +133,33 @@ def _refs_from_mgi_id(mgi_id, gene_mapper):
     if hgnc_id is None:
         logger.warning('Could not get HGNC ID for MGI ID %s' %
                        mgi_id)
+        return None
+    hgnc_ref = _refs_from_hgnc_id(hgnc_id, gene_mapper)
+    if hgnc_ref is None:
+        return None
+    ref.update(hgnc_ref)
+    return ref
+
+
+def map_rgd_ids(rgd_ids, gene_mapper):
+    """Return references based on a list of RGD IDs."""
+    refs = []
+    for rgd_id in rgd_ids:
+        if rgd_id.startswith('RGD:'):
+            rgd_id = rgd_id[4:]
+        rgd_ref = _refs_from_rgd_id(rgd_id, gene_mapper)
+        if rgd_ref is None:
+            continue
+        refs.append(rgd_ref)
+    return refs
+
+
+def _refs_from_rgd_id(rgd_id, gene_mapper):
+    ref = {'RGD': rgd_id}
+    hgnc_id = gene_mapper.get_hgnc_from_rgd(rgd_id)
+    if hgnc_id is None:
+        logger.warning('Could not get HGNC ID for RGD ID %s' %
+                       rgd_id)
         return None
     hgnc_ref = _refs_from_hgnc_id(hgnc_id, gene_mapper)
     if hgnc_ref is None:

--- a/genewalk/perform_statistics.py
+++ b/genewalk/perform_statistics.py
@@ -97,6 +97,8 @@ class GeneWalk(object):
         row.extend([np.nan for i in range(len(self.nvs))])
         if base_id_type == 'mgi_id':
             row = [gene.get('MGI', '')] + row
+        elif base_id_type == 'rgd_id':
+            row = [gene.get('RGD', '')] + row
         elif base_id_type == 'ensembl_id':
             row = [gene.get('ENSEMBL', '')] + row
         elif base_id_type == 'entrez_mouse' or \
@@ -116,8 +118,8 @@ class GeneWalk(object):
             only connected GO terms with mean padj < alpha_FDR are output.
         base_id_type : Optional[str]
             The type of gene IDs that were the basis of doing the analysis.
-            In case of mgi_id or ensembl_id, we prepend a column to the table
-            for MGI or ENSEMBL IDs, respectively.
+            In case of mgi_id, rgd_id or ensembl_id, we prepend a column to
+            the table for MGI, RGD, or ENSEMBL IDs, respectively.
             Default: hgnc_symbol
         """
         rows = []
@@ -166,6 +168,9 @@ class GeneWalk(object):
                             # If dealing with mouse genes, prepend the MGI ID
                             if base_id_type == 'mgi_id':
                                 row = [gene.get('MGI', '')] + row
+                            # If dealing with rat genes, prepend the RGD ID
+                            elif base_id_type == 'rgd_id':
+                                row = [gene.get('RGD', '')] + row
                             elif base_id_type == 'ensembl_id':
                                 row = [gene.get('ENSEMBL', '')] + row
                             elif base_id_type == 'entrez_mouse' or \
@@ -186,7 +191,7 @@ class GeneWalk(object):
                   'cilow_gene_padj', 'ciupp_gene_padj',
                   'cilow_pval', 'ciupp_pval']
         header.extend(['pval_rep'+str(i) for i in range(len(self.nvs))])
-        if base_id_type in {'mgi_id', 'ensembl_id', 'entrez_human',
+        if base_id_type in {'mgi_id', 'rgd_id', 'ensembl_id', 'entrez_human',
                             'entrez_mouse'}:
             header = [base_id_type] + header
 

--- a/genewalk/tests/test_gene_lists.py
+++ b/genewalk/tests/test_gene_lists.py
@@ -74,3 +74,16 @@ def test_read_gene_list_entrez_mouse():
     assert refs[0]['MGI'] == '95640'
     assert refs[0]['HGNC_SYMBOL'] == 'GAPDH'
 
+
+def test_read_gene_list_rgd():
+    rm = ResourceManager(base_folder=default_base_folder)
+    with open('test_gene_list_rgd.txt', 'w') as fh:
+        fh.write('2561\n')
+        fh.write('RGD:69323')
+    refs = read_gene_list('test_gene_list_rgd.txt',
+                          'rgd_id', rm)
+    assert len(refs) == 2, refs
+    assert refs[0]['RGD'] == '2561'
+    assert refs[0]['HGNC_SYMBOL'] == 'ERBB2'
+    assert refs[1]['RGD'] == '69323'
+    assert refs[1]['HGNC_SYMBOL'] == 'ERBB3'


### PR DESCRIPTION
This PR adds native support for taking RGD rat gene IDs (see https://rgd.mcw.edu/) as input in the gene list. Given #36, which adds RGD-HGNC mappings to the new resource file, this is now easy to support. Relevant for #27.