### PR TITLE
Test CLI directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,6 @@ jobs:
         pip install .[indra]
     - name: Run unit tests again
       run: nosetests genewalk -v --with-coverage --cover-inclusive --cover-package=genewalk
+    - name: Run CLI smoke tests
+      run: |
+        genewalk --project test_custom_genes --genes genewalk/tests/resources/custom_gene_list.txt --id_type custom --network_source sif_annot --network_file genewalk/tests/resources/test_sif_custom.sif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       run: nosetests genewalk -v --with-coverage --cover-inclusive --cover-package=genewalk
     - name: Run CLI smoke tests
       run: |
-        genewalk --project test_custom_genes --genes genewalk/tests/resources/custom_gene_list.txt --id_type custom --network_source sif_annot --network_file genewalk/tests/resources/test_sif_custom.sif
+        genewalk --project test_custom_genes --genes genewalk/tests/resources/custom_gene_list.txt --id_type custom --network_source sif_annot --network_file genewalk/tests/resources/test_sif_custom.sif --base_folder ~/genewalk/.test


### PR DESCRIPTION
This PR adds a new step to the automated tests where the CLI is called directly from the command line instead of being called with a wrapper with nosetests. This allows detecting issues with the argument parsing for the CLI.